### PR TITLE
修复JWT中间件硬编码密钥的安全问题

### DIFF
--- a/src/middleware/jwt.go
+++ b/src/middleware/jwt.go
@@ -1,12 +1,14 @@
 package middleware
 
 import (
+	"app/src/config"
+
 	jwtware "github.com/gofiber/contrib/jwt"
 	"github.com/gofiber/fiber/v2"
 )
 
 func JwtConfig() fiber.Handler {
 	return jwtware.New(jwtware.Config{
-		SigningKey: jwtware.SigningKey{Key: []byte("secret")},
+		SigningKey: jwtware.SigningKey{Key: []byte(config.JWTSecret)},
 	})
 }


### PR DESCRIPTION
## 问题

审计代码时发现  中的  函数硬编码了JWT签名密钥为 ：



项目的其他地方（token生成、auth中间件）都正确地从环境变量读取 ，但这个函数直接写死了密钥。虽然当前代码中  没有被路由调用，但如果将来有开发者误用此函数来保护API，攻击者只需用 "secret" 作为密钥伪造JWT，即可绕过认证访问任意接口。

## 修复

将硬编码的  改为从配置读取 ，与项目中其他地方保持一致：



## 影响范围

-  —  函数

这个改动不会影响现有功能，因为该函数目前未被路由调用，只是一个预防性安全修复。